### PR TITLE
Fix multifunction collapse arrow layout

### DIFF
--- a/mods/galacticWar/hook/lua/ui/game/layouts/multifunction_mini.lua
+++ b/mods/galacticWar/hook/lua/ui/game/layouts/multifunction_mini.lua
@@ -21,7 +21,8 @@ function SetLayout()
         UIUtil.UIFile('/game/tab-l-btn/tab-open_btn_over.dds'),
         UIUtil.UIFile('/game/tab-l-btn/tab-close_btn_dis.dds'),
         UIUtil.UIFile('/game/tab-l-btn/tab-open_btn_dis.dds'))
-    LayoutHelpers.AtLeftTopIn(controls.collapseArrow, savedParent, -3, 173) -- GW: old value 97
+    LayoutHelpers.AtLeftIn(controls.collapseArrow, savedParent, -3)
+    LayoutHelpers.AtVerticalCenterIn(controls.collapseArrow, controls.bg)
     controls.collapseArrow.Depth:Set(function() return controls.bg.Depth() + 10 end)
     
     LayoutHelpers.Below(controls.bg, econControl, 5)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed misalignment of the collapse arrow in the multifunction mini interface by adjusting its positioning to center vertically with the background element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Before:
<img width="378" height="160" alt="image" src="https://github.com/user-attachments/assets/92332197-68ee-46b1-83cf-0cc1778fe099" />

After:
<img width="391" height="190" alt="image" src="https://github.com/user-attachments/assets/68465681-fa7d-49c2-8da5-a223f8bbb3a8" />
