### PR TITLE
Display reinforcements timer in format MM:SS

### DIFF
--- a/lua/gwReinforcementList.lua
+++ b/lua/gwReinforcementList.lua
@@ -1,7 +1,7 @@
 gwReinforcements = {
     initialStructure = {
         {
-            playerName = "speed2",
+            playerId = 0,
             delay = 10,
             unitNames = {
                 "xsb2101",
@@ -14,15 +14,15 @@ gwReinforcements = {
     },
     passiveItems = {
         {
-            playerName = "speed2",
+            playerId = 0,
             itemNames = {"autorecall"}
         },
     },
     transportedUnits = {
         {
-            playerName = "speed2",
+            playerId = 0,
             called = false,
-            delay = 5,
+            delay = 60,
             group = 1,
             unitNames = {
                 "UEL0202","UEL0202","UEL0202","UEL0202","UEL0202","UEL0202", -- six pillars
@@ -30,7 +30,7 @@ gwReinforcements = {
             },
         },
         {
-            playerName = "speed2",
+            playerId = 0,
             called = false,
             delay = 150,
             group = 2,
@@ -40,7 +40,7 @@ gwReinforcements = {
             },
         },
         {
-            playerName = "speed2",
+            playerId = 0,
             called = false,
             delay = 200,
             group = 3,
@@ -50,7 +50,7 @@ gwReinforcements = {
             },
         },
         {
-            playerName = "speed2",
+            playerId = 0,
             called = false,
             delay = 200,
             group = 4,
@@ -60,7 +60,7 @@ gwReinforcements = {
             },
         },
         {
-            playerName = "speed2",
+            playerId = 0,
             called = false,
             delay = 200,
             group = 5,

--- a/lua/gwReinforcements.lua
+++ b/lua/gwReinforcements.lua
@@ -27,7 +27,6 @@ local teams = {-1, -1}
 
 ---@class ReinforcementGroupBase
 ---@field playerId integer
----@field playerName string
 ---@field avatarName string
 ---@field delay integer Delay in second before this group can be used
 ---@field unitNames BlueprintId[] List of units this group contains

--- a/lua/ui/ability_panel/abilities.lua
+++ b/lua/ui/ability_panel/abilities.lua
@@ -747,8 +747,9 @@ function StartCoolDownTimer(buttonName)
 
         button.buttonText:SetNeedsFrameUpdate(true)
 
-        UpdateTime = function(self, curTime)
-            self:SetText( math.ceil(curTime) )
+        local UpdateTime = function(self, curTime)
+            curTime = math.ceil(curTime)
+            self:SetText(string.format("%d:%02d", math.floor(curTime / 60), math.mod(curTime, 60)))
         end
 
         button.buttonText.OnFrame = function(self, delta)


### PR DESCRIPTION
<img width="361" height="79" alt="image" src="https://github.com/user-attachments/assets/f7886f72-593e-4041-9661-156a9c0ecf3d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Ability cooldown timers now show remaining time in minutes:seconds (mm:ss) for clearer readability.

* **Changes**
  * Reinforcement identifiers standardized across lists, and the first transport in the initial wave is delayed (impacting early-unit arrival timing).

* **Potential Impact**
  * Adjustments to reinforcement data may affect integrations that reference reinforcement ownership or identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->