### PR TITLE
Fix beacon transfer

### DIFF
--- a/mods/galacticWar/hook/lua/SimUtils.lua
+++ b/mods/galacticWar/hook/lua/SimUtils.lua
@@ -2,3 +2,6 @@
 ---@param data {Army: Army, Value: boolean}
 function SetOfferDraw(data)
 end
+
+-- Do not allow beacon transfer
+transferUnitsCategory = transferUnitsCategory - categories.REINFORCEMENTSBEACON


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reinforcement beacon transfers are now disallowed in Galactic War mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->